### PR TITLE
Integrated Redis caching to reduce database query overhead. Added Red…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,14 @@ actix-files = "0.6"
 actix-service = "2"
 jsonwebtoken = "9.3"
 serde = { version = "1" , features = ["derive"] }
-
+serde_json = "1"
 
 rusqlite = { version = "0.34" , features = ["chrono","bundled"] }
 chrono = { version = "0.4", features = ["serde"] }
 
 futures-util = "0.3.31"
+
+redis = "0.32"
 
 [profile.release]
 opt-level = "z"              # ลดขนาด binary (แทน "3" แบบ default)

--- a/run_redis.sh
+++ b/run_redis.sh
@@ -1,0 +1,1 @@
+docker run --name redis -d -p 6379:6379 redis:latest

--- a/src/infrastructure/app_state.rs
+++ b/src/infrastructure/app_state.rs
@@ -1,5 +1,6 @@
 use rusqlite::Connection;
 use std::sync::{Arc, Mutex};
+use redis::Client;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -8,4 +9,5 @@ pub struct AppState {
     pub password: String,
     pub secret_value: String,
     pub salt_key: String,
+    pub redis_client: Option<redis::Client>,
 }


### PR DESCRIPTION
…is client initialization, caching logic in `mq_functions`, and updated dependencies in `Cargo.toml`.
This pull request adds Redis caching support to improve the performance of the `/mq/functions` API endpoint by reducing database load for repeated requests. The changes include updating dependencies, modifying the application state to hold a Redis client, and implementing logic to cache and retrieve results from Redis. Additionally, a helper script for running Redis in Docker is provided.

**Redis integration and caching:**

* Added `redis` and `serde_json` dependencies to `Cargo.toml` to enable Redis client usage and JSON serialization.
* Updated `AppState` struct in `src/infrastructure/app_state.rs` to include an optional `redis_client` field for Redis connection management. [[1]](diffhunk://#diff-8669f6478c2436000570841d6e9cf8e1a3f4ce07e800c61ab0d3eb1672a01e6dR3) [[2]](diffhunk://#diff-8669f6478c2436000570841d6e9cf8e1a3f4ce07e800c61ab0d3eb1672a01e6dR12)
* In `src/main.rs`, initialized the Redis client from the `REDIS_URL` environment variable and stored it in `AppState`, with error handling for missing or invalid configuration. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL4-R6) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR32-R56)

**API caching logic:**

* Modified the `/mq/functions` endpoint in `src/interface/api/mq_log_handler.rs` to check Redis for a cached response before querying the database, and to cache new results after querying. [[1]](diffhunk://#diff-4b8afdca118ab0906783444f272bee782ba672c229cda54bb07baea2778e8e5eL7-R8) [[2]](diffhunk://#diff-4b8afdca118ab0906783444f272bee782ba672c229cda54bb07baea2778e8e5eR23-R57)

**Developer tooling:**

* Added a `run_redis.sh` script to start a Redis server in Docker for local development and testing.